### PR TITLE
Move necessary deps to prod

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,12 +17,14 @@
     "dev": "nodemon"
   },
   "dependencies": {
-    "express": "^4.16.4"
+    "@types/express": "^4.16.1",
+    "@types/node": "^10.14.6",
+    "express": "^4.16.4",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.1.1"
   },
   "devDependencies": {
-    "@types/express": "^4.16.1",
     "@types/jest": "^23.3.3",
-    "@types/node": "^10.14.6",
     "@types/supertest": "^2.0.7",
     "coveralls": "^3.0.2",
     "jest": "^23.6.0",
@@ -31,10 +33,8 @@
     "rimraf": "^2.6.2",
     "supertest": "^4.0.2",
     "ts-jest": "^23.10.3",
-    "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.1.1"
+    "tslint-config-prettier": "^1.15.0"
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
This PR moves the following dependencies from dev to prod as they are needed to build/run the backend service.

- `@types/express`
- `@types/node`
- `ts-node`
- `typescript`

Test with the following from the `backend` folder:
```bash
npm i --production
node --inspect -r ts-node/register src/index.ts
```